### PR TITLE
Add configurable header propagation for request and response hops

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -14,15 +14,17 @@ import (
 
 var (
 	// Flag variables for serve command
-	port                int
-	timeout             time.Duration
-	serviceName         string
-	logLevel            string
-	logFormat           string
-	logHeaders          bool
-	tlsCertFile         string
-	tlsKeyFile          string
-	upstreamTLSInsecure bool
+	port                     int
+	timeout                  time.Duration
+	serviceName              string
+	logLevel                 string
+	logFormat                string
+	logHeaders               bool
+	tlsCertFile              string
+	tlsKeyFile               string
+	upstreamTLSInsecure      bool
+	propagateRequestHeaders  bool
+	propagateResponseHeaders bool
 )
 
 // serveCmd represents the serve command
@@ -59,6 +61,8 @@ func init() {
 	serveCmd.Flags().StringVar(&tlsCertFile, "tls-cert", "", "Path to TLS certificate file (enables HTTPS when provided with --tls-key)")
 	serveCmd.Flags().StringVar(&tlsKeyFile, "tls-key", "", "Path to TLS key file (enables HTTPS when provided with --tls-cert)")
 	serveCmd.Flags().BoolVar(&upstreamTLSInsecure, "upstream-tls-insecure", false, "Skip TLS verification for upstream requests (useful for self-signed certs)")
+	serveCmd.Flags().BoolVar(&propagateRequestHeaders, "propagate-request-headers", true, "Propagate incoming request headers to upstream hops")
+	serveCmd.Flags().BoolVar(&propagateResponseHeaders, "propagate-response-headers", true, "Propagate upstream response headers back to the client")
 }
 
 // validateFlags validates all flag values before starting the server
@@ -134,11 +138,15 @@ func runServer(cmd *cobra.Command, args []string) error {
 		slog.Bool("log_headers", logHeaders),
 		slog.Bool("tls_enabled", tlsEnabled),
 		slog.Bool("upstream_tls_insecure", upstreamTLSInsecure),
+		slog.Bool("propagate_request_headers", propagateRequestHeaders),
+		slog.Bool("propagate_response_headers", propagateResponseHeaders),
 	)
 
 	handler := proxy.NewHandler(timeout, serviceName, logger,
 		proxy.WithHeaderLogging(logHeaders),
-		proxy.WithTLSInsecure(upstreamTLSInsecure))
+		proxy.WithTLSInsecure(upstreamTLSInsecure),
+		proxy.WithPropagateRequestHeaders(propagateRequestHeaders),
+		proxy.WithPropagateResponseHeaders(propagateResponseHeaders))
 
 	mux := http.NewServeMux()
 	mux.Handle("/", handler)

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -16,13 +16,13 @@ import (
 
 // Handler handles HTTP proxy requests
 type Handler struct {
-	client                  *http.Client
-	timeout                 time.Duration
-	serviceName             string
-	logger                  *slog.Logger
-	logHeaders              bool
-	tlsInsecure             bool
-	propagateRequestHeaders bool
+	client                   *http.Client
+	timeout                  time.Duration
+	serviceName              string
+	logger                   *slog.Logger
+	logHeaders               bool
+	tlsInsecure              bool
+	propagateRequestHeaders  bool
 	propagateResponseHeaders bool
 }
 

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -16,12 +16,14 @@ import (
 
 // Handler handles HTTP proxy requests
 type Handler struct {
-	client      *http.Client
-	timeout     time.Duration
-	serviceName string
-	logger      *slog.Logger
-	logHeaders  bool
-	tlsInsecure bool
+	client                  *http.Client
+	timeout                 time.Duration
+	serviceName             string
+	logger                  *slog.Logger
+	logHeaders              bool
+	tlsInsecure             bool
+	propagateRequestHeaders bool
+	propagateResponseHeaders bool
 }
 
 // Response represents the standard response format
@@ -48,6 +50,20 @@ func WithTLSInsecure(insecure bool) HandlerOption {
 	}
 }
 
+// WithPropagateRequestHeaders configures whether incoming request headers are forwarded to upstream hops
+func WithPropagateRequestHeaders(propagate bool) HandlerOption {
+	return func(h *Handler) {
+		h.propagateRequestHeaders = propagate
+	}
+}
+
+// WithPropagateResponseHeaders configures whether upstream response headers are forwarded to the client
+func WithPropagateResponseHeaders(propagate bool) HandlerOption {
+	return func(h *Handler) {
+		h.propagateResponseHeaders = propagate
+	}
+}
+
 // NewHandler creates a new proxy handler with structured logging
 func NewHandler(timeout time.Duration, serviceName string, logger *slog.Logger, opts ...HandlerOption) *Handler {
 	h := &Handler{
@@ -60,11 +76,13 @@ func NewHandler(timeout time.Duration, serviceName string, logger *slog.Logger, 
 				},
 			},
 		},
-		timeout:     timeout,
-		serviceName: serviceName,
-		logger:      logger,
-		logHeaders:  false,
-		tlsInsecure: false,
+		timeout:                  timeout,
+		serviceName:              serviceName,
+		logger:                   logger,
+		logHeaders:               false,
+		tlsInsecure:              false,
+		propagateRequestHeaders:  true,
+		propagateResponseHeaders: true,
 	}
 
 	// Apply options
@@ -374,6 +392,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Propagate incoming request headers to the next hop
+	if h.propagateRequestHeaders {
+		for k, v := range r.Header {
+			for _, val := range v {
+				nextReq.Header.Add(k, val)
+			}
+		}
+	}
+
 	forwardStartTime := time.Now()
 
 	// Forward to the next hop
@@ -461,10 +488,12 @@ func (h *Handler) forwardResponse(w http.ResponseWriter, resp *http.Response, lo
 
 	// Copy headers from downstream response
 	headerCount := 0
-	for k, v := range resp.Header {
-		for _, val := range v {
-			w.Header().Add(k, val)
-			headerCount++
+	if h.propagateResponseHeaders {
+		for k, v := range resp.Header {
+			for _, val := range v {
+				w.Header().Add(k, val)
+				headerCount++
+			}
 		}
 	}
 

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -1,9 +1,13 @@
 package proxy
 
 import (
+	"fmt"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -606,4 +610,143 @@ func TestDefaultTLSInsecure(t *testing.T) {
 	// Handler created without WithTLSInsecure option should have tlsInsecure=false by default
 	handler := NewHandler(30*time.Second, "test-service", logger)
 	assert.False(t, handler.tlsInsecure, "Default tlsInsecure should be false")
+}
+
+func TestDefaultHeaderPropagation(t *testing.T) {
+	logger := createTestLogger()
+	handler := NewHandler(30*time.Second, "test-service", logger)
+	assert.True(t, handler.propagateRequestHeaders, "Default propagateRequestHeaders should be true")
+	assert.True(t, handler.propagateResponseHeaders, "Default propagateResponseHeaders should be true")
+}
+
+func TestWithPropagateRequestHeaders(t *testing.T) {
+	logger := createTestLogger()
+
+	handler := NewHandler(30*time.Second, "test-service", logger, WithPropagateRequestHeaders(true))
+	assert.True(t, handler.propagateRequestHeaders)
+
+	handler = NewHandler(30*time.Second, "test-service", logger, WithPropagateRequestHeaders(false))
+	assert.False(t, handler.propagateRequestHeaders)
+}
+
+func TestWithPropagateResponseHeaders(t *testing.T) {
+	logger := createTestLogger()
+
+	handler := NewHandler(30*time.Second, "test-service", logger, WithPropagateResponseHeaders(true))
+	assert.True(t, handler.propagateResponseHeaders)
+
+	handler = NewHandler(30*time.Second, "test-service", logger, WithPropagateResponseHeaders(false))
+	assert.False(t, handler.propagateResponseHeaders)
+}
+
+func TestRequestHeaderPropagation(t *testing.T) {
+	var (
+		mu            sync.Mutex
+		receivedValue string
+	)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		receivedValue = r.Header.Get("X-Test-Header")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"status":200,"service":"upstream","message":"ok"}`)
+	}))
+	defer upstream.Close()
+
+	upstreamAddr := strings.TrimPrefix(upstream.URL, "http://")
+
+	tests := []struct {
+		name      string
+		propagate bool
+		wantValue string
+	}{
+		{
+			name:      "propagation enabled - header forwarded to upstream",
+			propagate: true,
+			wantValue: "test-value",
+		},
+		{
+			name:      "propagation disabled - header dropped",
+			propagate: false,
+			wantValue: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mu.Lock()
+			receivedValue = ""
+			mu.Unlock()
+
+			logger := createTestLogger()
+			handler := NewHandler(30*time.Second, "test-service", logger,
+				WithPropagateRequestHeaders(tt.propagate))
+
+			req := httptest.NewRequest(http.MethodGet, "/proxy/"+upstreamAddr+"/", nil)
+			req.Header.Set("X-Test-Header", "test-value")
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+
+			mu.Lock()
+			got := receivedValue
+			mu.Unlock()
+			assert.Equal(t, tt.wantValue, got)
+		})
+	}
+}
+
+func TestResponseHeaderPropagation(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Upstream-Header", "upstream-value")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"status":200,"service":"upstream","message":"ok"}`)
+	}))
+	defer upstream.Close()
+
+	upstreamAddr := strings.TrimPrefix(upstream.URL, "http://")
+
+	tests := []struct {
+		name       string
+		propagate  bool
+		wantHeader bool
+	}{
+		{
+			name:       "propagation enabled - upstream headers returned to client",
+			propagate:  true,
+			wantHeader: true,
+		},
+		{
+			name:       "propagation disabled - upstream headers dropped",
+			propagate:  false,
+			wantHeader: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := createTestLogger()
+			handler := NewHandler(30*time.Second, "test-service", logger,
+				WithPropagateResponseHeaders(tt.propagate))
+
+			req := httptest.NewRequest(http.MethodGet, "/proxy/"+upstreamAddr+"/", nil)
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+			if tt.wantHeader {
+				assert.Equal(t, "upstream-value", rr.Header().Get("X-Upstream-Header"),
+					"Upstream header should be present in response")
+			} else {
+				assert.Empty(t, rr.Header().Get("X-Upstream-Header"),
+					"Upstream header should not be present in response")
+			}
+		})
+	}
 }

--- a/tests/functional/topology_test.go
+++ b/tests/functional/topology_test.go
@@ -82,6 +82,93 @@ func TestProxyChainWithMultipleServices(t *testing.T) {
 
 }
 
+func TestHeaderPropagation(t *testing.T) {
+	ctx := context.Background()
+	nw := createTestNetwork(t, ctx)
+
+	// When service-a proxies service-b, service-b sets Content-Type: application/json.
+	// With propagation on (default), service-a copies that header to its response.
+	// With propagation off, service-a doesn't copy headers; Go's HTTP server then
+	// sniffs the JSON body and sets Content-Type: text/plain; charset=utf-8.
+	// This gives a reliable signal to distinguish the two modes.
+
+	t.Run("response_headers_propagated_by_default", func(t *testing.T) {
+		serviceConfigs := []ServiceConfig{
+			{Name: "hdr-a1", Port: "8080"},
+			{Name: "hdr-b1", Port: "8080"},
+		}
+		services := createServices(t, ctx, nw, serviceConfigs)
+
+		url := fmt.Sprintf("http://localhost:%s/proxy/%s:%s",
+			services[0].Port, services[1].Name, serviceConfigs[1].Port)
+		resp, err := http.Get(url)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"),
+			"Response headers from upstream should be propagated by default")
+	})
+
+	t.Run("response_headers_disabled", func(t *testing.T) {
+		serviceConfigs := []ServiceConfig{
+			{Name: "hdr-a2", Port: "8080", ExtraFlags: []string{"--propagate-response-headers=false"}},
+			{Name: "hdr-b2", Port: "8080"},
+		}
+		services := createServices(t, ctx, nw, serviceConfigs)
+
+		url := fmt.Sprintf("http://localhost:%s/proxy/%s:%s",
+			services[0].Port, services[1].Name, serviceConfigs[1].Port)
+		resp, err := http.Get(url)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.NotEqual(t, "application/json", resp.Header.Get("Content-Type"),
+			"Upstream response headers should be dropped when propagation is disabled")
+	})
+
+	t.Run("request_headers_propagated_by_default", func(t *testing.T) {
+		serviceConfigs := []ServiceConfig{
+			{Name: "hdr-a3", Port: "8080"},
+			{Name: "hdr-b3", Port: "8080"},
+		}
+		services := createServices(t, ctx, nw, serviceConfigs)
+
+		url := fmt.Sprintf("http://localhost:%s/proxy/%s:%s",
+			services[0].Port, services[1].Name, serviceConfigs[1].Port)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+		req.Header.Set("X-Test-Header", "test-value")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("request_headers_disabled", func(t *testing.T) {
+		serviceConfigs := []ServiceConfig{
+			{Name: "hdr-a4", Port: "8080", ExtraFlags: []string{"--propagate-request-headers=false"}},
+			{Name: "hdr-b4", Port: "8080"},
+		}
+		services := createServices(t, ctx, nw, serviceConfigs)
+
+		url := fmt.Sprintf("http://localhost:%s/proxy/%s:%s",
+			services[0].Port, services[1].Name, serviceConfigs[1].Port)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+		req.Header.Set("X-Test-Header", "test-value")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}
+
 func TestFaultInjection(t *testing.T) {
 	ctx := context.Background()
 

--- a/tests/functional/utils.go
+++ b/tests/functional/utils.go
@@ -17,11 +17,12 @@ import (
 
 // ServiceConfig represents the configuration for a single service
 type ServiceConfig struct {
-	Name     string
-	Port     string
-	TLS      bool
-	CertFile string
-	KeyFile  string
+	Name       string
+	Port       string
+	TLS        bool
+	CertFile   string
+	KeyFile    string
+	ExtraFlags []string
 }
 
 // ServiceResult represents a created service with its container and mapped port
@@ -73,12 +74,12 @@ func createServices(t *testing.T, ctx context.Context, nw *testcontainers.Docker
 				WaitingFor: wait.ForHTTP("/health").
 					WithPort(nat.Port(exposedPort)).
 					WithStartupTimeout(30 * time.Second),
-				Cmd: []string{
+				Cmd: append([]string{
 					"serve",
 					fmt.Sprintf("--port=%s", config.Port),
 					fmt.Sprintf("--service-name=%s", config.Name),
 					"--log-format=text",
-				},
+				}, config.ExtraFlags...),
 			}
 
 			container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{


### PR DESCRIPTION
## Summary

- Adds `--propagate-request-headers` flag (default `true`) to control whether incoming request headers are forwarded to upstream hops
- Adds `--propagate-response-headers` flag (default `true`) to control whether upstream response headers are returned to the client
- Both flags default to `true` so existing behaviour is unchanged; set to `false` to drop headers in either direction

## Test plan

- [ ] Unit tests: `TestRequestHeaderPropagation` and `TestResponseHeaderPropagation` verify forwarding/dropping using a `httptest` mock upstream
- [ ] Unit tests: `TestDefaultHeaderPropagation`, `TestWithPropagateRequestHeaders`, `TestWithPropagateResponseHeaders` verify option wiring and defaults
- [ ] Functional tests: `TestHeaderPropagation` exercises all four combinations end-to-end in containerised topologies